### PR TITLE
fix: ensure compatibility with PHP 5 by adjusting parameter type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 📄 Leia esta documentação em [Português 🇧🇷](README.pt.md)
 
+[![Maintainer](https://img.shields.io/badge/maintainer-@edquint-blue.svg?style=flat-square)](https://github.com/edquint)
+[![PHP from Packagist](https://img.shields.io/packagist/php-v/edquint/sql-logger.svg?style=flat-square)](https://packagist.org/packages/edquint/sql-logger)
+[![Latest Version](https://img.shields.io/github/release/edquint/sql-logger.svg?style=flat-square)](https://github.com/edquint/sql-logger/releases/)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://github.com/edquint/sql-logger/blob/main/LICENSE)
+[![Total Downloads](https://img.shields.io/packagist/dt/edquint/sql-logger.svg?style=flat-square)](https://packagist.org/packages/edquint/sql-logger)
+
 # PHP SQL Logger
 
 A simple library to generate SQL query logs and write them to log files.  

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,5 +1,11 @@
 📄 Read this documentation in [English 🇺🇸](README.md)
 
+[![Maintainer](https://img.shields.io/badge/maintainer-@edquint-blue.svg?style=flat-square)](https://github.com/edquint)
+[![PHP from Packagist](https://img.shields.io/packagist/php-v/edquint/sql-logger.svg?style=flat-square)](https://packagist.org/packages/edquint/sql-logger)
+[![Latest Version](https://img.shields.io/github/release/edquint/sql-logger.svg?style=flat-square)](https://github.com/edquint/sql-logger/releases/)
+[![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](https://github.com/edquint/sql-logger/blob/main/LICENSE)
+[![Total Downloads](https://img.shields.io/packagist/dt/edquint/sql-logger.svg?style=flat-square)](https://packagist.org/packages/edquint/sql-logger)
+
 # PHP SQL Logger
 
 Uma biblioteca simples para gerar logs de queries SQL e gravar em arquivos de log.  

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
+        "php": ">=5.0",
         "jdorn/sql-formatter": "^1.2"
     },
     "suggest": {

--- a/src/Factories/FormatterFactory.php
+++ b/src/Factories/FormatterFactory.php
@@ -18,9 +18,11 @@ use SqlLogger\Interfaces\FormatterInterface;
 class FormatterFactory
 {
     /**
+     * @param object $builder ORM builder used to build the query.
+     *
      * @return FormatterInterface|null
      */
-    public static function getFormatter(object $builder)
+    public static function getFormatter($builder)
     {
         if (class_exists('Doctrine_Core') && $builder instanceof \Doctrine_Query) {
             return Doctrine1Formatter::class;

--- a/src/Formatters/Doctrine1Formatter.php
+++ b/src/Formatters/Doctrine1Formatter.php
@@ -15,9 +15,11 @@ use SqlLogger\Interfaces\FormatterInterface;
 class Doctrine1Formatter implements FormatterInterface
 {
     /**
-     * @param \Doctrine_Query $builder
+     * @param \Doctrine_Query $builder ORM builder used to build the query.
+     *
+     * @return string The formatted SQL string.
      */
-    public static function formatter(object $builder)
+    public static function formatter($builder)
     {
         $query = $builder->getSqlQuery();
         $valuesFilter = $builder->getParams()['where'];

--- a/src/Formatters/Doctrine2Formatter.php
+++ b/src/Formatters/Doctrine2Formatter.php
@@ -17,9 +17,11 @@ use SqlLogger\Interfaces\FormatterInterface;
 class Doctrine2Formatter implements FormatterInterface
 {
     /**
-     * @param QueryBuilder|Query $builder
+     * @param QueryBuilder|Query $builder ORM builder used to build the query.
+     *
+     * @return string The formatted SQL string.
      */
-    public static function formatter(object $builder)
+    public static function formatter($builder)
     {
         if ($builder instanceof QueryBuilder) {
             $query = $builder->getQuery();

--- a/src/Formatters/EloquentFormatter.php
+++ b/src/Formatters/EloquentFormatter.php
@@ -17,10 +17,11 @@ use SqlLogger\Interfaces\FormatterInterface;
 class EloquentFormatter implements FormatterInterface
 {
     /**
-     * @param EloquentBuilder|QueryBuilder $builder
-     * @return string Query
+     * @param EloquentBuilder|QueryBuilder $builder ORM builder used to build the query.
+     *
+     * @return string The formatted SQL string.
      */
-    public static function formatter(object $builder)
+    public static function formatter($builder)
     {
         $sql = $builder->toSql();
         $bindings = $builder->getBindings();

--- a/src/Formatters/RawFormatter.php
+++ b/src/Formatters/RawFormatter.php
@@ -12,19 +12,27 @@ namespace SqlLogger\Formatters;
 
 class RawFormatter
 {
-    public static function formatter(string $rawQuery = '', array $queryParams = [])
+    /**
+     * @param string $rawQuery Raw Sql Query.
+     * @param array $queryParams Parameters for the SQL query.
+     *
+     * @return string The formatted SQL string.
+     */
+    public static function formatter($rawQuery = '', $queryParams = [])
     {
-        $isPositional = array_keys($queryParams) === range(0, count($queryParams) - 1);
+        if (!empty($queryParams)) {
+            $isPositional = array_keys($queryParams) === range(0, count($queryParams) - 1);
 
-        if ($isPositional) {
-            foreach ($queryParams as $param) {
-                $replacement = self::formatValue($param);
-                $rawQuery = preg_replace('/\?/', $replacement, $rawQuery, 1);
-            }
-        } else {
-            foreach (array_reverse($queryParams) as $key => $value) {
-                $replacement = self::formatValue($value);
-                $rawQuery = preg_replace("/(?<!:):$key\b/", $replacement, $rawQuery);
+            if ($isPositional) {
+                foreach ($queryParams as $param) {
+                    $replacement = self::formatValue($param);
+                    $rawQuery = preg_replace('/\?/', $replacement, $rawQuery, 1);
+                }
+            } else {
+                foreach (array_reverse($queryParams) as $key => $value) {
+                    $replacement = self::formatValue($value);
+                    $rawQuery = preg_replace("/(?<!:):$key\b/", $replacement, $rawQuery);
+                }
             }
         }
 

--- a/src/Handlers/LoggerFileHandler.php
+++ b/src/Handlers/LoggerFileHandler.php
@@ -15,7 +15,10 @@ use SqlLogger\Settings\LoggerConfig;
 
 class LoggerFileHandler implements LoggerInterface
 {
-    public function writeLog(string $query)
+    /**
+     * @param string $query The formatted SQL string.
+     */
+    public function writeLog($query)
     {
         $path = LoggerConfig::getLogPath();
 

--- a/src/Interfaces/FormatterInterface.php
+++ b/src/Interfaces/FormatterInterface.php
@@ -13,7 +13,9 @@ namespace SqlLogger\Interfaces;
 interface FormatterInterface
 {
     /**
-     * @return string
+     * @param object $builder ORM builder used to build the query.
+     *
+     * @return string The formatted SQL string.
      */
-    public static function formatter(object $builder);
+    public static function formatter($builder);
 }

--- a/src/Interfaces/LoggerInterface.php
+++ b/src/Interfaces/LoggerInterface.php
@@ -12,5 +12,8 @@ namespace SqlLogger\Interfaces;
 
 interface LoggerInterface
 {
-    public function writeLog(string $query);
+    /**
+     * @param string $query The formatted SQL string.
+     */
+    public function writeLog($query);
 }

--- a/src/LogSql.php
+++ b/src/LogSql.php
@@ -18,24 +18,39 @@ use SqlLogger\Settings\LoggerConfig;
 class LogSql
 {
     /**
-     * @param string $rawQuery Raw Sql Query
-     * @param array $queryParams Parameters for the SQL query
-     * @param bool $formatter Whether to format the query for better readability
-     * @return string
+     * Generates and returns a formatted SQL string from a raw SQL query.
+     *
+     * @param string $rawQuery Raw Sql Query.
+     * @param array|null $queryParams Parameters for the SQL query.
+     * @param bool $formatter Whether to format the query for better readability.
+     *
+     * @return string The formatted SQL string.
      */
-    public static function raw(string $rawQuery, array $queryParams = [], bool $formatter = true)
+    public static function raw($rawQuery, $queryParams = null, $formatter = true)
     {
-        $query = RawFormatter::formatter($rawQuery, $queryParams);
+        if (is_array($queryParams)) {
+            $rawQuery = RawFormatter::formatter($rawQuery, $queryParams);
+        }
 
-        return self::writeLog($query, $formatter);
+        return self::writeLog($rawQuery, $formatter);
     }
 
     /**
-     * @param object $builder ORM builder used to build the query
-     * @param bool $formatter Whether to format the query for better readability
-     * @return string|null
+     * Generates and returns a formatted SQL string from a ORM object.
+     *
+     * Supported ORM query builder objects:
+     * - \Doctrine_Query
+     * - \Doctrine\ORM\QueryBuilder
+     * - \Doctrine\ORM\Query
+     * - \Illuminate\Database\Eloquent\Builder
+     * - \Illuminate\Database\Query\Builder
+     *
+     * @param object $builder ORM builder used to build the query.
+     * @param bool $formatter Whether to format the query for better readability.
+     *
+     * @return string|null The formatted SQL string, or null if the input is invalid.
      */
-    public static function orm(object $builder, bool $formatter = true)
+    public static function orm($builder, $formatter = true)
     {
         $formatterClass = FormatterFactory::getFormatter($builder);
         if (!is_null($formatterClass)) {
@@ -47,7 +62,13 @@ class LogSql
         return null;
     }
 
-    private static function writeLog(string $query, bool $formatter)
+    /**
+     * @param object $builder ORM builder used to build the query.
+     * @param string The formatted SQL string.
+     *
+     * @return string The formatted SQL string.
+     */
+    private static function writeLog($query, $formatter)
     {
         if ($formatter) {
             $query = \SqlFormatter::format($query, false);


### PR DESCRIPTION
The previous code used type hints not supported in PHP 5.
This patch adjusts function parameters to use compatible typing.